### PR TITLE
Remove unused streaming APIs

### DIFF
--- a/go/ai_conversation_service.go
+++ b/go/ai_conversation_service.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"log"
 	"net"
 	"time"
@@ -27,11 +26,11 @@ func NewAIConversationService() *AIConversationService {
 	// Connect to Python gRPC service
 	host := "ai-service" // Docker service name
 	port := "50051"
-	
+
 	// Try to connect to gRPC server with retry logic
 	var conn *grpc.ClientConn
 	var err error
-	
+
 	for i := 0; i < 5; i++ {
 		conn, err = grpc.Dial(net.JoinHostPort(host, port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err == nil {
@@ -40,21 +39,21 @@ func NewAIConversationService() *AIConversationService {
 		log.Printf("Failed to connect to gRPC server (attempt %d/5): %v", i+1, err)
 		time.Sleep(2 * time.Second)
 	}
-	
+
 	if err != nil {
 		log.Printf("Warning: Could not connect to gRPC server: %v", err)
 		// Continue without gRPC connection - will simulate responses
 	}
-	
+
 	service := &AIConversationService{
 		grpcConn: conn,
 		sessions: make(map[string]bool),
 	}
-	
+
 	if conn != nil {
 		service.grpcClient = app.NewAIConversationServiceClient(conn)
 	}
-	
+
 	return service
 }
 
@@ -64,7 +63,7 @@ func (s *AIConversationService) StartConversation(
 	req *connect.Request[app.StartConversationRequest],
 ) (*connect.Response[app.StartConversationResponse], error) {
 	log.Printf("Starting conversation for user %s in language %s with character %s", req.Msg.Username, req.Msg.Language, req.Msg.Character)
-	
+
 	if s.grpcClient != nil {
 		// Call Python gRPC service
 		grpcResp, err := s.grpcClient.StartConversation(ctx, &app.StartConversationRequest{
@@ -73,30 +72,30 @@ func (s *AIConversationService) StartConversation(
 			Language:  req.Msg.Language,
 			Character: req.Msg.Character,
 		})
-		
+
 		if err != nil {
 			log.Printf("gRPC call failed: %v", err)
 			return nil, err
 		}
-		
+
 		// Store session
 		if grpcResp.Success {
 			s.sessions[grpcResp.SessionId] = true
 		}
-		
+
 		return connect.NewResponse(grpcResp), nil
 	}
-	
+
 	// Fallback simulation if gRPC not available
 	sessionID := generateSessionID()
 	s.sessions[sessionID] = true
-	
+
 	resp := &app.StartConversationResponse{
 		SessionId:    sessionID,
 		Success:      true,
 		ErrorMessage: "",
 	}
-	
+
 	return connect.NewResponse(resp), nil
 }
 
@@ -106,35 +105,35 @@ func (s *AIConversationService) EndConversation(
 	req *connect.Request[app.EndConversationRequest],
 ) (*connect.Response[app.EndConversationResponse], error) {
 	log.Printf("Ending conversation session %s", req.Msg.SessionId)
-	
+
 	if s.grpcClient != nil {
 		// Call Python gRPC service
 		grpcResp, err := s.grpcClient.EndConversation(ctx, &app.EndConversationRequest{
 			SessionId: req.Msg.SessionId,
 			UserId:    req.Msg.UserId,
 		})
-		
+
 		if err != nil {
 			log.Printf("gRPC call failed: %v", err)
 			return nil, err
 		}
-		
+
 		// Remove session locally if successful
 		if grpcResp.Success {
 			delete(s.sessions, req.Msg.SessionId)
 		}
-		
+
 		return connect.NewResponse(grpcResp), nil
 	}
-	
+
 	// Fallback simulation
 	delete(s.sessions, req.Msg.SessionId)
-	
+
 	resp := &app.EndConversationResponse{
 		Success:      true,
 		ErrorMessage: "",
 	}
-	
+
 	return connect.NewResponse(resp), nil
 }
 
@@ -144,7 +143,7 @@ func (s *AIConversationService) SendMessage(
 	req *connect.Request[app.AIConversationRequest],
 ) (*connect.Response[app.AIConversationResponse], error) {
 	log.Printf("Processing message from user %s in language %s with character %s", req.Msg.Username, req.Msg.Language, req.Msg.Character)
-	
+
 	if s.grpcClient != nil {
 		// Call Python gRPC service
 		grpcResp, err := s.grpcClient.SendMessage(ctx, &app.AIConversationRequest{
@@ -155,15 +154,15 @@ func (s *AIConversationService) SendMessage(
 			Content:   req.Msg.Content,
 			Timestamp: req.Msg.Timestamp,
 		})
-		
+
 		if err != nil {
 			log.Printf("gRPC call failed: %v", err)
 			return nil, err
 		}
-		
+
 		return connect.NewResponse(grpcResp), nil
 	}
-	
+
 	// Fallback simulation with character-specific responses
 	var responseText string
 	character := req.Msg.Character
@@ -193,196 +192,18 @@ func (s *AIConversationService) SendMessage(
 	default:
 		responseText = "Hello! I'm your AI language learning assistant. How can I help you practice today?"
 	}
-	
+
 	resp := &app.AIConversationResponse{
-		ResponseId:  generateResponseID(),
-		Language:    req.Msg.Language,
-		Timestamp:   timestamppb.Now(),
-		IsFinal:     true,
+		ResponseId: generateResponseID(),
+		Language:   req.Msg.Language,
+		Timestamp:  timestamppb.Now(),
+		IsFinal:    true,
 		Content: &app.AIConversationResponse_TextMessage{
 			TextMessage: responseText,
 		},
 	}
-	
+
 	return connect.NewResponse(resp), nil
-}
-
-// StreamConversation handles bidirectional streaming conversation
-func (s *AIConversationService) StreamConversation(
-	ctx context.Context,
-	stream *connect.BidiStream[app.AIConversationRequest, app.AIConversationResponse],
-) error {
-	log.Println("Starting streaming conversation")
-	
-	if s.grpcClient != nil {
-		// Use gRPC streaming
-		grpcStream, err := s.grpcClient.StreamConversation(ctx)
-		if err != nil {
-			log.Printf("Failed to start gRPC stream: %v", err)
-			return err
-		}
-		
-		// Forward messages between Connect stream and gRPC stream
-		go func() {
-			for {
-				req, err := stream.Receive()
-				if err != nil {
-					grpcStream.CloseSend()
-					return
-				}
-				
-				grpcReq := &app.AIConversationRequest{
-					UserId:    req.UserId,
-					Username:  req.Username,
-					Language:  req.Language,
-					Character: req.Character,
-					Content:   req.Content,
-					Timestamp: req.Timestamp,
-				}
-				
-				if err := grpcStream.Send(grpcReq); err != nil {
-					log.Printf("Failed to send to gRPC stream: %v", err)
-					return
-				}
-			}
-		}()
-		
-		for {
-			grpcResp, err := grpcStream.Recv()
-			if err != nil {
-				return err
-			}
-			
-			if err := stream.Send(grpcResp); err != nil {
-				return err
-			}
-		}
-	}
-	
-	// Fallback simulation
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			req, err := stream.Receive()
-			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return nil
-				}
-				return err
-			}
-			
-			log.Printf("Received streaming message from user %s", req.Username)
-			
-			time.Sleep(500 * time.Millisecond)
-			
-			character := req.Character
-			if character == "" {
-				character = "friend"
-			}
-
-			var responseText string
-			switch req.Language {
-			case "vi":
-				switch character {
-				case "parent":
-					responseText = "Mẹ nghe rồi con. Hãy kể cho mẹ nghe thêm nhé!"
-				case "sister":
-					responseText = "Em nghe thấy rồi! Kể tiếp đi anh/chị!"
-				default:
-					responseText = "Tôi đã nghe thấy tin nhắn của bạn. Hãy tiếp tục trò chuyện!"
-				}
-			case "ja":
-				switch character {
-				case "parent":
-					responseText = "お母さんは聞いてるよ。もっと話してね。"
-				case "sister":
-					responseText = "聞いた聞いた！続きを教えて！"
-				default:
-					responseText = "メッセージを受け取ったよ。続けて話そう！"
-				}
-			default:
-				responseText = "I received your message. Let's continue practicing!"
-			}
-			
-			resp := &app.AIConversationResponse{
-				ResponseId:  generateResponseID(),
-				Language:    req.Language,
-				Timestamp:   timestamppb.Now(),
-				IsFinal:     true,
-				Content: &app.AIConversationResponse_TextMessage{
-					TextMessage: responseText,
-				},
-			}
-			
-			if err := stream.Send(resp); err != nil {
-				return err
-			}
-		}
-	}
-}
-
-// StreamConversationEvents handles server-side streaming of conversation events
-func (s *AIConversationService) StreamConversationEvents(
-	ctx context.Context,
-	req *connect.Request[app.StartConversationRequest],
-	stream *connect.ServerStream[app.ConversationEvent],
-) error {
-	log.Printf("Starting conversation event stream for user %s", req.Msg.Username)
-	
-	// Start a conversation first
-	startReq := connect.NewRequest(&app.StartConversationRequest{
-		UserId:    req.Msg.UserId,
-		Username:  req.Msg.Username,
-		Language:  req.Msg.Language,
-		Character: req.Msg.Character,
-	})
-	
-	startResp, err := s.StartConversation(ctx, startReq)
-	if err != nil {
-		return err
-	}
-	
-	// Send initial conversation started event
-	event := &app.ConversationEvent{
-		Type:      app.ConversationEvent_CONVERSATION_STARTED,
-		UserId:    req.Msg.UserId,
-		SessionId: startResp.Msg.SessionId,
-		Timestamp: timestamppb.Now(),
-	}
-	
-	if err := stream.Send(event); err != nil {
-		return err
-	}
-	
-	// Keep the stream alive and send periodic events
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-	
-	for {
-		select {
-		case <-ctx.Done():
-			// End conversation
-			endReq := connect.NewRequest(&app.EndConversationRequest{
-				SessionId: startResp.Msg.SessionId,
-				UserId:    req.Msg.UserId,
-			})
-			s.EndConversation(ctx, endReq)
-			
-			// Send conversation ended event
-			endEvent := &app.ConversationEvent{
-				Type:      app.ConversationEvent_CONVERSATION_ENDED,
-				UserId:    req.Msg.UserId,
-				SessionId: startResp.Msg.SessionId,
-				Timestamp: timestamppb.Now(),
-			}
-			return stream.Send(endEvent)
-			
-		case <-ticker.C:
-			log.Println("Sending conversation keepalive event")
-		}
-	}
 }
 
 // Helper functions

--- a/go/main.go
+++ b/go/main.go
@@ -34,7 +34,7 @@ func Logger() gin.HandlerFunc {
 func main() {
 	// Create AI service
 	aiService := NewAIConversationService()
-	
+
 	// Create Connect RPC handlers
 	aiPath, aiHandler := appv1connect.NewAIConversationServiceHandler(aiService)
 
@@ -45,7 +45,7 @@ func main() {
 	// Create Gin router for regular HTTP endpoints
 	router := gin.Default()
 	router.Use(Logger())
-	
+
 	// Configure CORS
 	router.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"http://localhost:3000", "http://localhost:3003"},
@@ -53,7 +53,7 @@ func main() {
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization", "Accept", "Accept-Encoding", "Accept-Language", "Connection", "Host", "User-Agent", "Connect-Protocol-Version", "Connect-Timeout-Ms"},
 		ExposeHeaders:    []string{"Content-Length", "Connect-Protocol-Version"},
 		AllowCredentials: true,
-		MaxAge:          12 * time.Hour,
+		MaxAge:           12 * time.Hour,
 	}))
 
 	router.GET("/", func(c *gin.Context) {
@@ -80,15 +80,13 @@ func main() {
 	log.Println("  - /connect/app.v1.AIConversationService/StartConversation")
 	log.Println("  - /connect/app.v1.AIConversationService/EndConversation")
 	log.Println("  - /connect/app.v1.AIConversationService/SendMessage")
-	log.Println("  - /connect/app.v1.AIConversationService/StreamConversation")
-	log.Println("  - /connect/app.v1.AIConversationService/StreamConversationEvents")
 
 	// Use h2c for HTTP/2 without TLS (required for streaming)
 	server := &http.Server{
 		Addr:    ":8000",
 		Handler: h2c.NewHandler(router, &http2.Server{}),
 	}
-	
+
 	if err := server.ListenAndServe(); err != nil {
 		log.Fatal("Server failed to start:", err)
 	}

--- a/proto/app/ai_conversation.proto
+++ b/proto/app/ai_conversation.proto
@@ -28,28 +28,6 @@ message AIConversationResponse {
   bool is_final = 6; // Whether this is the final response for the request
 }
 
-// Streaming conversation events
-message ConversationEvent {
-  enum EventType {
-    CONVERSATION_STARTED = 0;
-    USER_MESSAGE = 1;
-    AI_RESPONSE = 2;
-    CONVERSATION_ENDED = 3;
-    ERROR = 4;
-  }
-  
-  EventType type = 1;
-  string user_id = 2;
-  string session_id = 3;
-  google.protobuf.Timestamp timestamp = 4;
-  
-  oneof event_data {
-    AIConversationRequest user_message = 5;
-    AIConversationResponse ai_response = 6;
-    string error_message = 7;
-  }
-}
-
 // Session management
 message StartConversationRequest {
   string user_id = 1;

--- a/proto/app/ai_conversation_service.proto
+++ b/proto/app/ai_conversation_service.proto
@@ -14,10 +14,4 @@ service AIConversationService {
   
   // Send a single message and get response (unary)
   rpc SendMessage(AIConversationRequest) returns (AIConversationResponse);
-  
-  // Bidirectional streaming conversation
-  rpc StreamConversation(stream AIConversationRequest) returns (stream AIConversationResponse);
-  
-  // Stream conversation events (server-side streaming)
-  rpc StreamConversationEvents(StartConversationRequest) returns (stream ConversationEvent);
 }


### PR DESCRIPTION
## Summary
- drop unused streaming RPCs and ConversationEvent from protobuf definitions
- remove StreamConversation and StreamConversationEvents handlers from Go and Python services
- trim logging of removed endpoints

## Testing
- `python -m py_compile python/grpc_server.py`
- `make generate` *(fails: /root/go/bin/buf: No such file or directory)*
- `make setup` *(fails: module github.com/bufbuild/buf/cmd/buf: Get "https://proxy.golang.org/github.com/bufbuild/buf/cmd/buf/@v/list": Forbidden)*
- `go test ./...` *(no output; likely waiting for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b28e0efe7883249a7c19980ef4eed3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Live streaming replies and event feeds have been removed. Clients must use single request/response interactions.
- Refactor
  - Conversation flow simplified to one-shot interactions: Start Conversation, Send Message, and End Conversation remain available without streaming.
- Chores
  - Startup logs updated to reflect only non-streaming endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->