### PR TITLE
docs: align README with conversation app spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,126 @@
-# go-next-template
+# 外国語会話練習アプリ（仮称）
 
-## template 概要
+AI キャラクターとの音声会話を通じて外国語を学習できるアプリケーションです。Next.js ベースのフロントエンドから Go 製バックエンド、Python 製 AI サービスまでをモノレポで管理しており、gRPC ストリーミングを介してリアルタイムな会話体験を提供します。
 
-この template は、go と next.js を使用したアプリケーションのテンプレートです。
+## 主な機能
 
-### go
+- OS のマイクを用いた AI とのリアルタイム音声会話
+- 会話相手となる 3 種類のキャラクター選択機能
+- Web Speech API を利用した音声認識と、AI 応答の音声合成
+- 会話履歴の表示
 
-使用バージョン: 1.24.1
-go で gRPC を採用しており、buf を使用して proto ファイルから go のコードを自動生成しています。
+### キャラクター一覧
 
-### next.js
+| キャラクター | 性別・年代 | 特徴 | ベトナム語音声 | 日本語音声 |
+| --- | --- | --- | --- | --- |
+| Friend | 男性 / 20 代 | カジュアルで親しみやすい友達キャラ | vi-VN-Standard-B | ja-JP-Standard-C |
+| Parent | 女性 / 40 代 | 温かく経験豊富な母親キャラ | vi-VN-Standard-A | ja-JP-Standard-A |
+| Sister | 女性 / 20 代前半 | 親しげで少しいたずらっぽい妹キャラ | vi-VN-Standard-A | ja-JP-Standard-A |
 
-使用バージョン: 15.2.4
-使用バージョン: next.js では、app router を採用しています。
+### 対応言語
 
-### proto
+- ベトナム語（`vi`）
+- 日本語（`ja`）
 
-使用バージョン: 1.30.0
-使用バージョン: buf を使用して proto ファイルから go のコードと ts のコードを自動生成しています。
-buf のバージョンはv2を採用しています。
+## 画面構成
 
+- `/` 認証画面（暫定的に遷移のみ実装予定）
+- `/talk` 会話画面（ChatGPT の音声会話体験に近い UI を想定）
 
+## アーキテクチャ概要
 
-## ディレクトリ構造
+```
+Next.js (Connect-Web, Web Speech API)
+          │
+          ▼
+       Go API (Gin, Connect-Go)
+          │
+          ▼
+    Python AI サービス (gRPC, Gemini, TTS)
+```
+
+- フロントエンドは Connect-Web を経由して Go のバックエンドへストリーミング接続
+- Go の API が Python で実装した AI 会話サービスと通信し、音声応答を生成
+- 生成したテキスト・音声をフロントエンドへ返却し、ユーザーが選択した言語とキャラクター設定を反映
+
+## 技術スタック
+
+### フロントエンド
+
+- Next.js 15.2.4（App Router）
+- TypeScript
+- Connect-Web（gRPC-Web クライアント）
+- Web Speech API（音声認識・音声合成制御）
+
+### バックエンド
+
+- Go 1.24.1
+- Connect-Go（gRPC 互換サーバー）
+- Gin（HTTP フレームワーク）
+
+### AI サービス
+
+- Python 3.11
+- Google Gemini API（会話生成）
+- Google Cloud Text-to-Speech（音声合成）
+- gRPC（サービス間通信）
+
+### インフラ / ツール
+
+- Docker & Docker Compose
+- Protocol Buffers
+- Buf（v2 系）
+
+## ディレクトリ構成
 
 ```
 .
-├── go/             # Goアプリケーションのルートディレクトリ
-│   └── gen/        # protoファイルから自動生成されたGoコード
-├── next/           # Next.jsアプリケーションのルートディレクトリ
+├── go/             # Go バックエンド
+│   └── gen/        # proto から自動生成された Go コード
+├── next/           # Next.js フロントエンド
 │   └── src/
-│       └── gen/    # protoファイルから自動生成されたTypeScriptコード
-└── proto/          # Protocol Buffersの定義ファイル
-    ├── app/        # アプリケーション用のprotoファイル
-    ├── buf.gen.yaml # Buf生成設定
-    ├── buf.yaml    # Bufワークスペース設定
-    └── Makefile    # protoファイル関連のコマンド
+│       └── gen/    # proto から自動生成された TypeScript コード
+├── python/         # AI サービス
+└── proto/          # Protocol Buffers 定義と Buf 設定
+    ├── app/        # アプリケーション用 proto 定義
+    ├── buf.gen.yaml
+    ├── buf.yaml
+    └── Makefile
 ```
+
+## 開発環境
+
+### 必要な環境変数
+
+```bash
+# Google Cloud 認証
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+
+# Gemini API
+GOOGLE_GEMINI_API_KEY=your_gemini_api_key
+```
+
+### 主要コマンド
+
+```bash
+# Proto のコード生成
+cd proto
+make generate
+
+# フロントエンド開発
+cd next
+pnpm dev
+
+# Go バックエンド開発
+cd go
+make run
+
+# すべてのサービスを起動
+docker compose up --build -d
+```
+
+## 補足
+
+- 初期実装ではデータベースを使用せず、会話体験の構築を優先します。
+- 各キャラクターは異なるプロンプトと音声設定を持ち、状況に応じて音声 API を切り替える設計です。
+- 詳細なアプリ仕様は `docs/application/app.md` を参照してください。


### PR DESCRIPTION
## Summary
- rewrite the root README to describe the foreign-language conversation practice app features
- document the architecture, tech stack, directory layout, and development commands in Japanese

## Testing
- not run (docs change)

------
https://chatgpt.com/codex/tasks/task_e_68f3c38e45548324b4b41c0b6bba886f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and expanded project README with comprehensive sections covering project overview, main features, character list, supported languages, system architecture, directory structure, and development environment setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->