### PR TITLE
Add OpenAI Whisper transcription helper

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,6 +3,7 @@ grpcio>=1.59.0
 grpcio-tools>=1.59.0
 protobuf>=6.32.0
 google-genai
+openai>=1.30.0
 python-dotenv>=1.0.0
 
 # Optional audio dependencies - can be installed if needed


### PR DESCRIPTION
## Summary
- add optional OpenAI Whisper client initialization to the AI conversation service
- provide a helper method to transcribe audio via Whisper with basic logging
- include the OpenAI Python SDK in service dependencies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69298627e8d48324ad55a6e1568376a1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional OpenAI Whisper transcription support for audio-to-text conversion when configured with your API credentials. Existing speech-to-text and text-to-speech features remain available.

* **Chores**
  * Updated dependencies to include the OpenAI package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->